### PR TITLE
fix: use boxedslice rather than serde-big-array to fix stackoverflows when deserializing snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxarray"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c639599bce1200f19d5081999a79ab80f1ee05d41b699a37e0ff78050442ef"
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,9 +605,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3259,6 +3265,7 @@ dependencies = [
 name = "partyboy-core"
 version = "0.1.0"
 dependencies = [
+ "boxarray",
  "console_error_panic_hook",
  "criterion",
  "image",
@@ -3905,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "serde-big-array"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
 ]

--- a/partyboy-core/Cargo.toml
+++ b/partyboy-core/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+boxarray = "1.3.0"
+console_error_panic_hook = { version = "0.1", optional = true }
 log = "0.4"
 paste = "1"
+rmp-serde = { version = "1.1.1", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde-big-array = { version = "0.5.1", optional = true }
 thiserror = "1"
 wasm-bindgen = { version = "0.2.83", optional = true }
-console_error_panic_hook = { version = "0.1", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde-big-array = { version = "0.4.1", optional = true }
-rmp-serde = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partyboy-core/src/apu/sweep.rs
+++ b/partyboy-core/src/apu/sweep.rs
@@ -96,9 +96,7 @@ impl Sweep {
         }
 
         if self.enabled && self.period > 0 {
-            let Some(new_freq) = self.calc_freq(freq) else {
-                return None;
-            };
+            let new_freq = self.calc_freq(freq)?;
 
             if new_freq <= 2047 && self.slope > 0 && self.calc_freq(new_freq).is_none() {
                 return None;

--- a/partyboy-core/src/cartridge/mod.rs
+++ b/partyboy-core/src/cartridge/mod.rs
@@ -22,6 +22,8 @@ trait CartridgeInterface {
     fn write_ram(&mut self, addr: u16, value: u8);
 
     fn ram_banks(&self) -> &Vec<[u8; 0x2000]>;
+
+    #[allow(unused)] // This will be needed for writing save files
     fn has_ram(&self) -> bool;
 
     fn load_rom(&mut self, rom: Vec<[u8; 0x4000]>);

--- a/partyboy-core/src/cartridge/serialize.rs
+++ b/partyboy-core/src/cartridge/serialize.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "serde")]
-
 use std::marker::PhantomData;
 
 use serde::{de::Visitor, ser::SerializeSeq, Deserializer, Serializer};

--- a/partyboy-core/src/common/boxed_slice.rs
+++ b/partyboy-core/src/common/boxed_slice.rs
@@ -1,0 +1,141 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut, Index, IndexMut},
+    slice::SliceIndex,
+};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(from = "Vec<T>", into = "Vec<T>"))]
+pub struct BoxedSlice<T, const N: usize>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    inner: Box<[T; N]>,
+}
+
+impl<T, const N: usize> BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    pub fn new_with(initial: T) -> Self {
+        Self {
+            inner: vec![initial; N].into_boxed_slice().try_into().unwrap(),
+        }
+    }
+
+    pub fn new_with_slice(val: [T; N]) -> Self {
+        Self {
+            inner: Box::new(val),
+        }
+    }
+}
+
+impl<T, const N: usize> Default for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    fn default() -> Self {
+        Self::new_with(T::default())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, const N: usize> From<Vec<T>> for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    fn from(value: Vec<T>) -> Self {
+        Self {
+            inner: value.into_boxed_slice().try_into().unwrap(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, const N: usize> From<BoxedSlice<T, N>> for Vec<T>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    fn from(value: BoxedSlice<T, N>) -> Self {
+        value.inner.to_vec()
+    }
+}
+
+impl<T, const N: usize> AsRef<[T; N]> for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    fn as_ref(&self) -> &[T; N] {
+        &self.inner
+    }
+}
+
+impl<T, const N: usize> Deref for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    type Target = [T; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, const N: usize> DerefMut for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T, const N: usize, Idx> Index<Idx> for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+    Idx: SliceIndex<[T], Output = T>,
+{
+    type Output = T;
+
+    fn index(&self, index: Idx) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl<T, const N: usize, Idx> IndexMut<Idx> for BoxedSlice<T, N>
+where
+    T: Clone + Copy + Default + Debug,
+    Idx: SliceIndex<[T], Output = T>,
+{
+    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
+        &mut self.inner[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoxedSlice;
+
+    #[test]
+    fn test_serde() {
+        let mut boxed_slice = BoxedSlice::<u8, 0xFF>::default();
+        boxed_slice
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, el)| *el = i as u8);
+
+        let serialized_arr = serde_json::to_string(&boxed_slice).expect("Unable to serialize arr");
+
+        let deserialized_arr: BoxedSlice<u8, 0xFF> =
+            serde_json::from_str(&serialized_arr).expect("Unable to deserialize arr");
+
+        deserialized_arr
+            .iter()
+            .enumerate()
+            .for_each(|(i, el)| assert_eq!(i, *el as usize));
+    }
+}

--- a/partyboy-core/src/common/mod.rs
+++ b/partyboy-core/src/common/mod.rs
@@ -6,55 +6,56 @@ use std::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+mod boxed_slice;
+
+pub use boxed_slice::BoxedSlice;
+
 /// A type to wrap 2d arrays so we can serialize and deserialize them more easily
 /// by converting it into/from a 1d vector.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
-    serde(from = "SerializableD2Array<T>", into = "SerializableD2Array<T>")
+    serde(from = "SerializableD2Array", into = "SerializableD2Array")
 )]
-pub(crate) struct D2Array<T, const N: usize, const M: usize>
-where
-    T: Default + Clone + Copy,
-{
-    array: Box<[[T; N]; M]>,
+pub(crate) struct D2Array<const N: usize, const M: usize> {
+    array: Box<[[u8; N]; M]>,
 }
 
-#[cfg(feature = "serde")]
-#[derive(Serialize, Deserialize)]
-struct SerializableD2Array<T> {
-    // Ideally we could use const generic expressions and define an array [T; N * M]
-    // and then just use mem::transmute to convert to/from the D2Array type
-    vec: Vec<T>,
-}
-
-#[cfg(feature = "serde")]
-impl<T, const N: usize, const M: usize> From<SerializableD2Array<T>> for D2Array<T, N, M>
-where
-    T: Default + Clone + Copy,
-{
-    fn from(val: SerializableD2Array<T>) -> Self {
-        let mut array = [[T::default(); N]; M];
-
-        let mut vec_iter = val.vec.chunks_exact(N);
-        for inner_arr in &mut array {
-            let chunk = vec_iter.next().expect("Unable to get chunk");
-            inner_arr.copy_from_slice(chunk);
-        }
-
-        D2Array {
-            array: Box::new(array),
+impl<const N: usize, const M: usize> D2Array<N, M> {
+    pub fn new_zeroed() -> Self {
+        Self {
+            array: boxarray::boxarray(0),
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, const N: usize, const M: usize> From<D2Array<T, N, M>> for SerializableD2Array<T>
-where
-    T: Default + Clone + Copy,
-{
-    fn from(val: D2Array<T, N, M>) -> Self {
+#[derive(Serialize, Deserialize)]
+struct SerializableD2Array {
+    // Ideally we could use const generic expressions and define an array [T; N * M]
+    // and then just use mem::transmute to convert to/from the D2Array type
+    vec: Vec<u8>,
+}
+
+#[cfg(feature = "serde")]
+impl<const N: usize, const M: usize> From<SerializableD2Array> for D2Array<N, M> {
+    fn from(val: SerializableD2Array) -> Self {
+        let mut d2 = Self::new_zeroed();
+
+        let mut vec_iter = val.vec.chunks_exact(N);
+        for inner_arr in &mut *d2.array {
+            let chunk = vec_iter.next().expect("Unable to get chunk");
+            inner_arr.copy_from_slice(chunk);
+        }
+
+        d2
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const N: usize, const M: usize> From<D2Array<N, M>> for SerializableD2Array {
+    fn from(val: D2Array<N, M>) -> Self {
         let mut vec = Vec::new();
         for m in 0..M {
             for n in 0..N {
@@ -66,62 +67,40 @@ where
     }
 }
 
-impl<T, const N: usize, const M: usize> From<[[T; N]; M]> for D2Array<T, N, M>
-where
-    T: Default + Clone + Copy,
-{
-    fn from(array: [[T; N]; M]) -> Self {
-        Self {
-            array: Box::new(array),
-        }
-    }
-}
-
-impl<T, const N: usize, const M: usize> AsRef<[[T; N]; M]> for D2Array<T, N, M>
-where
-    T: Default + Clone + Copy,
-{
-    fn as_ref(&self) -> &[[T; N]; M] {
+impl<const N: usize, const M: usize> AsRef<[[u8; N]; M]> for D2Array<N, M> {
+    fn as_ref(&self) -> &[[u8; N]; M] {
         &self.array
     }
 }
 
-impl<T, const N: usize, const M: usize> Deref for D2Array<T, N, M>
-where
-    T: Default + Clone + Copy,
-{
-    type Target = [[T; N]; M];
+impl<const N: usize, const M: usize> Deref for D2Array<N, M> {
+    type Target = [[u8; N]; M];
 
     fn deref(&self) -> &Self::Target {
         &self.array
     }
 }
 
-impl<T, const N: usize, const M: usize> DerefMut for D2Array<T, N, M>
-where
-    T: Default + Clone + Copy,
-{
+impl<const N: usize, const M: usize> DerefMut for D2Array<N, M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.array
     }
 }
 
-impl<T, const N: usize, const M: usize, Idx> Index<Idx> for D2Array<T, N, M>
+impl<const N: usize, const M: usize, Idx> Index<Idx> for D2Array<N, M>
 where
-    T: Default + Clone + Copy,
-    Idx: SliceIndex<[[T; N]], Output = [T; N]>,
+    Idx: SliceIndex<[[u8; N]], Output = [u8; N]>,
 {
-    type Output = [T; N];
+    type Output = [u8; N];
 
     fn index(&self, index: Idx) -> &Self::Output {
         &self.array[index]
     }
 }
 
-impl<T, const N: usize, const M: usize, Idx> IndexMut<Idx> for D2Array<T, N, M>
+impl<const N: usize, const M: usize, Idx> IndexMut<Idx> for D2Array<N, M>
 where
-    T: Default + Clone + Copy,
-    Idx: SliceIndex<[[T; N]], Output = [T; N]>,
+    Idx: SliceIndex<[[u8; N]], Output = [u8; N]>,
 {
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
         &mut self.array[index]
@@ -134,42 +113,42 @@ mod tests {
 
     #[test]
     fn d2array_is_indexable() {
-        let arr: D2Array<u8, 0x100, 2> = [[0; 0x100]; 2].into();
+        let arr: D2Array<0x100, 2> = D2Array::new_zeroed();
         let _ = arr[0];
     }
 
     #[test]
     fn d2array_is_mutable_via_index() {
-        let mut arr: D2Array<u8, 0x100, 2> = [[0; 0x100]; 2].into();
+        let mut arr: D2Array<0x100, 2> = D2Array::new_zeroed();
         arr[0][1] = 10;
     }
 
     #[test]
     fn d2array_should_serde_correctly() {
-        let mut arr: D2Array<usize, 0x100, 2> = [[0; 0x100]; 2].into();
+        let mut arr: D2Array<250, 2> = D2Array::new_zeroed();
 
         for (i, val) in arr[0].iter_mut().enumerate() {
-            *val = i;
+            *val = i as u8;
         }
-        for i in (0..0x100).rev() {
-            arr[1][i] = i.abs_diff(0x100);
+        for i in (0u8..250).rev() {
+            arr[1][i as usize] = i.abs_diff(250);
         }
 
         let serialized_arr = serde_json::to_string(&arr).expect("Unable to serialize arr");
 
-        let deserialized_arr: D2Array<usize, 0x100, 2> =
+        let deserialized_arr: D2Array<250, 2> =
             serde_json::from_str(&serialized_arr).expect("Unable to deserialize arr");
 
         // verify values
         deserialized_arr.array[0]
             .iter()
             .enumerate()
-            .for_each(|(i, val): (usize, &usize)| assert_eq!(i, *val));
+            .for_each(|(i, val): (usize, &u8)| assert_eq!(i, *val as usize));
 
         deserialized_arr.array[1]
             .iter()
             .enumerate()
             .rev()
-            .for_each(|(i, val): (usize, &usize)| assert_eq!(i, val.abs_diff(0x100)));
+            .for_each(|(i, val): (usize, &u8)| assert_eq!(i, val.abs_diff(250) as usize));
     }
 }

--- a/partyboy-core/src/cpu/instructions.rs
+++ b/partyboy-core/src/cpu/instructions.rs
@@ -369,7 +369,7 @@ macro_rules! __jr {
         InstructionStep::Standard(|cpu, _| {
             let jmp_amount = cpu.operand8 as i8;
             if jmp_amount < 0 {
-                cpu.pc = cpu.pc.wrapping_sub(jmp_amount.abs() as u16);
+                cpu.pc = cpu.pc.wrapping_sub(jmp_amount.unsigned_abs() as u16);
             } else {
                 cpu.pc = cpu.pc.wrapping_add(jmp_amount as u16);
             }

--- a/partyboy-core/src/interrupts.rs
+++ b/partyboy-core/src/interrupts.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::cpu::Cpu;
 
 #[cfg(feature = "serde")]
@@ -34,14 +36,14 @@ impl InterruptFlag {
     }
 }
 
-impl ToString for InterruptFlag {
-    fn to_string(&self) -> String {
+impl Display for InterruptFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InterruptFlag::VBlank => String::from("VBlank"),
-            InterruptFlag::Stat => String::from("Stat"),
-            InterruptFlag::Timer => String::from("Timer"),
-            InterruptFlag::Serial => String::from("Serial"),
-            InterruptFlag::Joypad => String::from("Joypad"),
+            InterruptFlag::VBlank => write!(f, "VBlank"),
+            InterruptFlag::Stat => write!(f, "Stat"),
+            InterruptFlag::Timer => write!(f, "Timer"),
+            InterruptFlag::Serial => write!(f, "Serial"),
+            InterruptFlag::Joypad => write!(f, "Joypad"),
         }
     }
 }

--- a/partyboy-core/src/lib.rs
+++ b/partyboy-core/src/lib.rs
@@ -54,7 +54,7 @@ impl GameBoy {
     fn new(
         rom: Option<Vec<u8>>,
         ram: Option<Vec<u8>>,
-        bios: [u8; 2304],
+        bios: [u8; 0x900],
         serial_write_handler: SerialWriteHandler,
     ) -> Self {
         let cartridge = rom.map(|rom| Cartridge::new(rom, ram));

--- a/partyboy-core/tests/mooneye.rs
+++ b/partyboy-core/tests/mooneye.rs
@@ -8,7 +8,7 @@ use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
 const PASSING_FIB: [u8; 6] = [3, 5, 8, 13, 21, 34];
 
-fn assert_output(buffer: &Vec<u8>) {
+fn assert_output(buffer: &[u8]) {
     assert_eq!(buffer.len(), 6);
 
     for i in 0..6 {


### PR DESCRIPTION
For some reason, lots of tests were failing just trying to build the emulator. The builder would cause a stackoverflow when trying to build the emulator with "bios skip" enabled. 

Upon further investigation, it was the deserialization of the emulator causing a stackoverflow. And using a crate that allowed printing a backtrace upon stackoverflow, there were a suspicous amount of `serde-big-array` calls in it. So replace all 1d arrays marked with `serde-big-array ` with a cusotm `BoxedSlice` type which has `serde` support