### PR TITLE
feat: mass rom runner cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ perf.data.old
 !test/test_roms/README.md
 /test_roms
 
+# runner output
+partyboy-mass-runner/out
+
 # hmm
 /bin/_cgb_boot.bin

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ perf.data.old
 /test_roms
 
 # runner output
-partyboy-mass-runner/out
+output/
 
 # hmm
 /bin/_cgb_boot.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -994,7 +994,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -1272,6 +1272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1418,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2489,7 +2502,7 @@ dependencies = [
  "console",
  "portable-atomic",
  "rayon",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unit-prefix",
  "web-time",
 ]
@@ -3139,6 +3152,18 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3858,11 +3883,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
+ "crossbeam",
+ "ctrlc",
  "image",
  "indicatif",
  "panic-message",
  "partyboy-core",
- "rayon",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5383,15 +5411,9 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -988,15 +988,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width",
- "windows-sys 0.52.0",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1542,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enumflags2"
@@ -2483,16 +2482,16 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.7"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "instant",
- "number_prefix",
  "portable-atomic",
  "rayon",
- "unicode-width",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -3285,12 +3284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,7 +3857,7 @@ name = "partyboy-mass-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.18",
+ "clap 4.6.1",
  "image",
  "indicatif",
  "panic-message",
@@ -4064,12 +4057,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"
@@ -5401,10 +5388,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1539,12 @@ source = "git+https://github.com/emilk/egui.git?rev=e76c919c7e70c208c9a6209b9fe3
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumflags2"
@@ -2463,6 +2482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "rayon",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,6 +3734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "panic-message"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,6 +3857,19 @@ dependencies = [
  "partyboy-core",
  "rfd",
  "spin_sleep_util",
+]
+
+[[package]]
+name = "partyboy-mass-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.18",
+ "image",
+ "indicatif",
+ "panic-message",
+ "partyboy-core",
+ "rayon",
 ]
 
 [[package]]
@@ -4006,6 +4064,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "partyboy-frontend",
     "partyboy-frontend-debug",
     "partyboy-core",
-    "partyboy-util"
+    "partyboy-util", 
+    "partyboy-mass-runner"
 ]
 default-members = [
     "partyboy-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ spin_sleep = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "tracing-log"] }
 tracing-appender = "0.2"
+anyhow = "1"
+indicatif = { version = "0.18", features = ["rayon"] }
+panic-message = "0.3"
+rayon = "1"
+partyboy-core = { path = "partyboy-core", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ winit = "0.30"
 cpal = "0.17"
 crossbeam = "0.8"
 ringbuffer = "0.16"
+ctrlc = "3.4"
 lz4_flex = "0.11"
 spin_sleep = "1"
 tracing = "0.1"
@@ -56,6 +57,10 @@ overflow-checks = false
 lto = true
 panic = "abort"
 codegen-units = 1
+
+[profile.release-unwind]
+inherits = "release"
+panic = "unwind"
 
 [profile.test]
 opt-level = 3

--- a/partyboy-mass-runner/Cargo.toml
+++ b/partyboy-mass-runner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "partyboy-mass-runner"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4.4", features = ["derive"] }
+image = "0.24"
+indicatif = { version = "0.17", features = ["rayon"] }
+panic-message = "0.3"
+partyboy-core = { path = "../partyboy-core" }
+rayon = "1.8"

--- a/partyboy-mass-runner/Cargo.toml
+++ b/partyboy-mass-runner/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+crossbeam = { workspace = true }
+ctrlc = { workspace = true }
 image = { workspace = true }
 indicatif = { workspace = true }
 panic-message = { workspace = true }
 partyboy-core = { workspace = true }
-rayon = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/partyboy-mass-runner/Cargo.toml
+++ b/partyboy-mass-runner/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.4", features = ["derive"] }
-image = "0.24"
-indicatif = { version = "0.17", features = ["rayon"] }
-panic-message = "0.3"
-partyboy-core = { path = "../partyboy-core" }
-rayon = "1.8"
+anyhow = { workspace = true }
+clap = { workspace = true }
+image = { workspace = true }
+indicatif = { workspace = true }
+panic-message = { workspace = true }
+partyboy-core = { workspace = true }
+rayon = { workspace = true }

--- a/partyboy-mass-runner/src/args.rs
+++ b/partyboy-mass-runner/src/args.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    #[arg(short, long)]
+    pub roms_dir: PathBuf,
+
+    #[arg(short, long)]
+    pub output: PathBuf,
+
+    #[arg(short, long)]
+    pub bios: Option<PathBuf>,
+
+    /// Target emulation speed as a multiplier of real time (e.g. 3.0 = 3x real-time).
+    /// Values <= 0 mean unlimited / original max-speed behavior.
+    #[arg(long, default_value_t = 3.0)]
+    pub speed_factor: f64,
+
+    /// Resume a previous run. ROMs with both `{name}_40.png` and `{name}_120.png`,
+    /// or a `{name}.failed` marker, are skipped.
+    #[arg(long)]
+    pub resume: bool,
+
+    /// Number of concurrent emulator workers (default: logical CPUs, capped at 16).
+    #[arg(short = 'j', long)]
+    pub jobs: Option<usize>,
+}

--- a/partyboy-mass-runner/src/emulator.rs
+++ b/partyboy-mass-runner/src/emulator.rs
@@ -1,0 +1,138 @@
+use std::time::{Duration, Instant};
+
+use image::{ImageBuffer, RgbImage};
+use partyboy_core::builder::GameBoyBuilder;
+use partyboy_core::input::Keycode;
+use partyboy_core::ppu::rgb::Rgb;
+use partyboy_core::GameBoy;
+
+use crate::rom::{rom_display_name, Rom};
+use crate::types::{RunResult, WorkerStatus};
+
+pub fn into_img(fb: Vec<Rgb>) -> RgbImage {
+    let mut img: RgbImage = ImageBuffer::new(160, 144);
+    fb.into_iter()
+        .flat_map(|rgb| [rgb.r, rgb.g, rgb.b])
+        .zip(img.iter_mut())
+        .for_each(|(px, img_px)| *img_px = px);
+    img
+}
+
+/// Run `ticks` emulator ticks, optionally throttling to `speed_factor` * real time.
+/// `status` is updated with absolute emulated seconds (offset by `base_seconds` for
+/// multi-phase runs).
+pub fn run_emulated_ticks<F>(
+    gb: &mut GameBoy,
+    ticks: u64,
+    speed_factor: f64,
+    mut on_tick: F,
+    status: Option<&WorkerStatus>,
+    base_seconds: f64,
+) where
+    F: FnMut(&mut GameBoy, u64),
+{
+    if speed_factor <= 0.0 {
+        let update_every = partyboy_core::SPEED / 4;
+        for i in 0..ticks {
+            let _ = gb.tick();
+            on_tick(gb, i);
+            if let Some(s) = status {
+                if i % update_every == 0 {
+                    let secs = base_seconds + (i as f64 / partyboy_core::SPEED as f64);
+                    s.update_emulated(secs as u64);
+                }
+            }
+        }
+        return;
+    }
+
+    let start = Instant::now();
+    let check_every = partyboy_core::SPEED;
+
+    for i in 0..ticks {
+        let _ = gb.tick();
+        on_tick(gb, i);
+
+        if i % check_every == 0 {
+            let emulated_in_phase = i as f64 / partyboy_core::SPEED as f64;
+            let absolute = base_seconds + emulated_in_phase;
+
+            if let Some(s) = status {
+                s.update_emulated(absolute as u64);
+            }
+
+            let desired = emulated_in_phase / speed_factor;
+            let real = start.elapsed().as_secs_f64();
+            if real < desired {
+                std::thread::sleep(Duration::from_secs_f64(desired - real));
+            }
+        }
+    }
+}
+
+/// Run one ROM through the QA pass (40s warm-up + 80s with button mashing) and capture
+/// a screenshot at each phase boundary.
+pub fn run_one_rom(
+    rom: Rom,
+    bios: Option<&[u8]>,
+    speed_factor: f64,
+    status: Option<&WorkerStatus>,
+) -> RunResult {
+    let rom_name = rom_display_name(&rom.path);
+
+    let result = std::panic::catch_unwind(|| {
+        let mut builder = GameBoyBuilder::new();
+        if let Some(b) = bios {
+            builder = builder.bios(b.to_vec());
+        }
+        let mut gb = builder.rom(rom.bytes).build().unwrap();
+
+        // Phase 1: 0-40s warm-up (no inputs)
+        run_emulated_ticks(
+            &mut gb,
+            partyboy_core::SPEED * 40,
+            speed_factor,
+            |_, _| {},
+            status,
+            0.0,
+        );
+        let fourty = gb.get_frame_buffer().to_vec();
+
+        // Phase 2: 40-120s alternating Start / A every half second
+        let mut pressed = false;
+        run_emulated_ticks(
+            &mut gb,
+            partyboy_core::SPEED * 80,
+            speed_factor,
+            |gb, tick| {
+                if tick % (partyboy_core::SPEED / 2) == 0 {
+                    if pressed {
+                        gb.key_down(Keycode::A);
+                        gb.key_up(Keycode::Start);
+                    } else {
+                        gb.key_up(Keycode::A);
+                        gb.key_down(Keycode::Start);
+                    }
+                    pressed = !pressed;
+                }
+            },
+            status,
+            40.0,
+        );
+        let onetwenty = gb.get_frame_buffer().to_vec();
+
+        RunResult::Success {
+            fourty_seconds_frame_buffer: fourty,
+            onetwenty_seconds_frame_buffer: onetwenty,
+            rom_path: rom.path,
+        }
+    });
+
+    match result {
+        Ok(r) => r,
+        Err(payload) => RunResult::Fail {
+            rom_name,
+            error: payload,
+        },
+    }
+}

--- a/partyboy-mass-runner/src/main.rs
+++ b/partyboy-mass-runner/src/main.rs
@@ -1,0 +1,253 @@
+use std::{
+    any::Any,
+    fs, iter, panic,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Result};
+use clap::Parser;
+use image::{ImageBuffer, RgbImage};
+use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
+use partyboy_core::{builder::GameBoyBuilder, input::Keycode, ppu::rgb::Rgb};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    roms_dir: PathBuf,
+
+    #[arg(short, long)]
+    output: PathBuf,
+
+    #[arg(short, long)]
+    bios: Option<PathBuf>,
+}
+
+#[allow(unused)]
+enum RunResult {
+    Success {
+        rom_name: String,
+        fourty_seconds_frame_buffer: Vec<Rgb>,
+        onetwenty_seconds_frame_buffer: Vec<Rgb>,
+        rom_path: PathBuf,
+    },
+    Fail {
+        rom_name: String,
+        error: Box<dyn Any + Send>,
+    },
+}
+
+struct Rom {
+    bytes: Vec<u8>,
+    path: PathBuf,
+}
+
+fn get_all_roms(path: &Path) -> Result<Vec<Rom>> {
+    fs::read_dir(path)?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if entry.file_type().ok()?.is_dir() {
+                return None;
+            }
+            Some(entry.path())
+        })
+        .map(|path| {
+            let bytes = fs::read(&path)?;
+            Ok(Rom { bytes, path })
+        })
+        .collect::<Result<Vec<_>>>()
+}
+
+fn into_img(fb: Vec<Rgb>) -> RgbImage {
+    let mut img: RgbImage = ImageBuffer::new(160, 144);
+    fb.into_iter()
+        .flat_map(|rgb| [rgb.r, rgb.g, rgb.b])
+        .zip(img.iter_mut())
+        .for_each(|(px, img_px)| *img_px = px);
+    img
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if !args.roms_dir.is_dir() {
+        bail!("roms_dir is not a directory!");
+    }
+
+    if args.output.is_file() {
+        bail!("output is not a directory!");
+    }
+
+    let bios = if let Some(bios_path) = args.bios {
+        Some(fs::read(bios_path)?)
+    } else {
+        None
+    };
+
+    let roms = get_all_roms(&args.roms_dir)?;
+
+    println!("Found {} roms.", roms.len());
+
+    let pb = ProgressBar::new(roms.len() as u64);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos:>7}/{len:7} ({eta})",
+        )
+        .unwrap()
+        .progress_chars("#>-"),
+    );
+
+    let run_results = roms
+        .into_par_iter()
+        .progress_with(pb)
+        .map(|rom| {
+            let rom_name = rom
+                .path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or(anyhow!("Unable to get filename"))
+                .unwrap()
+                .to_owned();
+
+            panic::set_hook(Box::new(|_| {}));
+
+            let result = panic::catch_unwind({
+                let rom_name = rom_name.clone();
+                let rom_path = rom.path.clone();
+                || {
+                    let mut builder = GameBoyBuilder::new();
+
+                    if let Some(bios) = &bios {
+                        builder = builder.bios(bios.clone());
+                    }
+
+                    let mut gb = builder.rom(rom.bytes).build().unwrap();
+                    for _ in 0..(partyboy_core::SPEED * 40) {
+                        let _ = gb.tick();
+                    }
+
+                    let fourty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
+
+                    let mut pressed = false;
+                    for tick in 0..(partyboy_core::SPEED * 80) {
+                        let _ = gb.tick();
+
+                        if tick % (partyboy_core::SPEED / 2) == 0 {
+                            match pressed {
+                                true => {
+                                    gb.key_down(Keycode::A);
+                                    gb.key_up(Keycode::Start);
+                                }
+                                false => {
+                                    gb.key_up(Keycode::A);
+                                    gb.key_down(Keycode::Start);
+                                }
+                            }
+                            pressed = !pressed;
+                        }
+                    }
+
+                    let onetwenty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
+
+                    RunResult::Success {
+                        rom_name,
+                        fourty_seconds_frame_buffer,
+                        onetwenty_seconds_frame_buffer,
+                        rom_path,
+                    }
+                }
+            });
+
+            match result {
+                Ok(run_result) => run_result,
+                Err(payload) => RunResult::Fail {
+                    rom_name,
+                    error: payload,
+                },
+            }
+        })
+        .collect::<Vec<RunResult>>();
+
+    if !args.output.exists() {
+        fs::create_dir(&args.output)?;
+    }
+
+    println!();
+    println!();
+
+    let mut html = Vec::new();
+
+    for result in run_results {
+        match result {
+            RunResult::Success {
+                rom_name,
+                fourty_seconds_frame_buffer,
+                onetwenty_seconds_frame_buffer,
+                mut rom_path,
+            } => {
+                let fourty = into_img(fourty_seconds_frame_buffer);
+                let onetwenty = into_img(onetwenty_seconds_frame_buffer);
+
+                rom_path.set_extension("");
+                let name = rom_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .ok_or(anyhow!("Unable to get filename"))?;
+
+                fourty.save(args.output.join(format!("{name}_40.png")))?;
+                onetwenty.save(args.output.join(format!("{name}_120.png")))?;
+
+                let html_fragment = format!(
+                    r#"
+                    <div class="runner-result runner-success">
+                        <div>{rom_name}</div>
+                        <img src="{name}_40.png">
+                        <img src="{name}_120.png">
+                    </div>
+                "#
+                );
+
+                html.push(html_fragment);
+            }
+            RunResult::Fail { rom_name, error } => {
+                let msg = panic_message::panic_message(&error);
+
+                let html_fragment = format!(
+                    r#"
+                    <div class="runner-result runner-fail">
+                        <div>{rom_name}</div>
+                        <div>{msg}</div>
+                    </div>
+                "#
+                );
+
+                html.push(html_fragment);
+
+                eprintln!("A run failed:");
+                eprintln!("Rom: {rom_name}");
+                eprintln!("Error: {msg}");
+                eprintln!();
+            }
+        }
+    }
+
+    let html = ["
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <title>Page Title</title>
+        </head>
+        <body>
+    "
+    .to_owned()]
+    .into_iter()
+    .chain(html)
+    .chain(iter::once("</body></html>".to_owned()))
+    .collect::<String>();
+
+    fs::write(args.output.join("report.html"), html)
+        .map_err(|_| anyhow!("Unable to write html report file"))?;
+
+    Ok(())
+}

--- a/partyboy-mass-runner/src/main.rs
+++ b/partyboy-mass-runner/src/main.rs
@@ -1,297 +1,209 @@
-use std::{
-    any::Any,
-    fs, iter, panic,
-    path::{Path, PathBuf},
+mod args;
+mod emulator;
+mod rom;
+mod types;
+mod writer;
+
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{fs, panic, process, thread};
+
+use anyhow::{bail, Result};
+use clap::Parser;
+use crossbeam::channel;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use panic::AssertUnwindSafe;
+
+use crate::args::Args;
+use crate::emulator::run_one_rom;
+use crate::rom::{filter_completed_for_resume, get_all_roms, rom_display_name, Rom};
+use crate::types::{
+    current_shutdown, new_shutdown, request_shutdown, RunResult, ShutdownState, WorkerStatus,
 };
 
-use anyhow::{anyhow, bail, Result};
-use clap::Parser;
-use image::{ImageBuffer, RgbImage};
-use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
-use partyboy_core::{builder::GameBoyBuilder, input::Keycode, ppu::rgb::Rgb, GameBoy};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
-#[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
-struct Args {
-    #[arg(short, long)]
-    roms_dir: PathBuf,
-
-    #[arg(short, long)]
-    output: PathBuf,
-
-    #[arg(short, long)]
-    bios: Option<PathBuf>,
-
-    /// Target emulation speed as a multiplier of real time (e.g. 3.0 = 3x real-time).
-    /// Values <= 0 mean unlimited / original max-speed behavior.
-    #[arg(long, default_value_t = 3.0)]
-    speed_factor: f64,
-}
-
-#[allow(unused)]
-enum RunResult {
-    Success {
-        rom_name: String,
-        fourty_seconds_frame_buffer: Vec<Rgb>,
-        onetwenty_seconds_frame_buffer: Vec<Rgb>,
-        rom_path: PathBuf,
-    },
-    Fail {
-        rom_name: String,
-        error: Box<dyn Any + Send>,
-    },
-}
-
-struct Rom {
-    bytes: Vec<u8>,
-    path: PathBuf,
-}
-
-fn get_all_roms(path: &Path) -> Result<Vec<Rom>> {
-    fs::read_dir(path)?
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            if entry.file_type().ok()?.is_dir() {
-                return None;
-            }
-            Some(entry.path())
-        })
-        .map(|path| {
-            let bytes = fs::read(&path)?;
-            Ok(Rom { bytes, path })
-        })
-        .collect::<Result<Vec<_>>>()
-}
-
-fn into_img(fb: Vec<Rgb>) -> RgbImage {
-    let mut img: RgbImage = ImageBuffer::new(160, 144);
-    fb.into_iter()
-        .flat_map(|rgb| [rgb.r, rgb.g, rgb.b])
-        .zip(img.iter_mut())
-        .for_each(|(px, img_px)| *img_px = px);
-    img
-}
-
-/// Run exactly `ticks` calls to `gb.tick()`, invoking `on_tick(gb, i)` after each tick.
-/// When `speed_factor > 0` the loop dynamically sleeps (using real wall time)
-/// so that the *average* emulation rate does not exceed `speed_factor` × real time.
-/// A factor <= 0 means "run as fast as possible" (original unlimited behavior).
-fn run_emulated_ticks<F>(gb: &mut GameBoy, ticks: u64, speed_factor: f64, mut on_tick: F)
-where
-    F: FnMut(&mut GameBoy, u64),
-{
-    if speed_factor <= 0.0 {
-        for i in 0..ticks {
-            let _ = gb.tick();
-            on_tick(gb, i);
-        }
-        return;
-    }
-
-    let start = std::time::Instant::now();
-    // Check once per emulated second — very low overhead and yields nice long sleeps
-    // that the OS scheduler can actually deschedule the thread for.
-    let check_every = partyboy_core::SPEED;
-
-    for i in 0..ticks {
-        let _ = gb.tick();
-        on_tick(gb, i);
-
-        if i % check_every == 0 {
-            let emulated_seconds = i as f64 / partyboy_core::SPEED as f64;
-            let desired_real_seconds = emulated_seconds / speed_factor;
-            let real_seconds = start.elapsed().as_secs_f64();
-            if real_seconds < desired_real_seconds {
-                std::thread::sleep(std::time::Duration::from_secs_f64(
-                    desired_real_seconds - real_seconds,
-                ));
-            }
-        }
-    }
-}
-
 fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let args = Args::parse();
 
     if !args.roms_dir.is_dir() {
         bail!("roms_dir is not a directory!");
     }
-
     if args.output.is_file() {
         bail!("output is not a directory!");
     }
 
-    let bios = if let Some(bios_path) = args.bios {
-        Some(fs::read(bios_path)?)
-    } else {
-        None
-    };
+    let bios: Option<Arc<[u8]>> = args
+        .bios
+        .as_deref()
+        .map(fs::read)
+        .transpose()?
+        .map(Arc::from);
 
-    let speed_factor = args.speed_factor;
+    let mut roms = get_all_roms(&args.roms_dir)?;
 
-    let roms = get_all_roms(&args.roms_dir)?;
+    if args.resume {
+        if !args.output.exists() {
+            fs::create_dir_all(&args.output)?;
+        }
+        let before = roms.len();
+        roms = filter_completed_for_resume(roms, &args.output);
+        tracing::info!(
+            "Resume mode: {} already done, {} remaining.",
+            before - roms.len(),
+            roms.len()
+        );
+    }
 
-    println!("Found {} roms.", roms.len());
+    let total_to_process = roms.len();
+    tracing::info!("Found {} ROMs to process.", total_to_process);
 
-    let pb = ProgressBar::new(roms.len() as u64);
-    pb.set_style(
+    let jobs = args.jobs.unwrap_or_else(|| {
+        thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .min(16)
+    });
+
+    let (work_tx, work_rx) = channel::unbounded::<Rom>();
+    let (result_tx, result_rx) = channel::unbounded::<RunResult>();
+    let completed_count = Arc::new(AtomicUsize::new(0));
+
+    for rom in roms {
+        let _ = work_tx.send(rom);
+    }
+    drop(work_tx);
+
+    let mp = MultiProgress::new();
+
+    // Route panic output through mp.println so it doesn't interleave with the bar
+    // redraws (stderr writes by the default hook leave half-rendered bars stuck in
+    // the scrollback). The full message is still persisted via the writer thread's
+    // .failed marker.
+    {
+        let mp = mp.clone();
+        panic::set_hook(Box::new(move |info| {
+            let name = thread::current().name().unwrap_or("<unnamed>").to_string();
+            let _ = mp.println(format!("thread '{name}' {info}"));
+        }));
+    }
+
+    let global_bar = mp.add(ProgressBar::new(total_to_process as u64));
+    global_bar.set_style(
         ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos:>7}/{len:7} ({eta})",
+            "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos:>5}/{len:5} ROMs ({eta})",
         )
         .unwrap()
-        .progress_chars("#>-"),
+        .progress_chars("##-"),
+    );
+    global_bar.set_message("Overall");
+
+    let worker_bars: Vec<ProgressBar> = (0..jobs)
+        .map(|i| {
+            let pb = mp.add(ProgressBar::new(120));
+            pb.set_style(
+                ProgressStyle::with_template(&format!(
+                    "  [W{i:02}] {{spinner:.yellow}} {{msg:<20.20}} [{{bar:30.green/blue}}] {{pos:>3}}/{{len}}s"
+                ))
+                .unwrap()
+                .progress_chars("##-"),
+            );
+            pb.set_message("idle");
+            pb
+        })
+        .collect();
+
+    let writer_handle = writer::spawn_writer_thread(
+        result_rx,
+        args.output.clone(),
+        completed_count.clone(),
+        Some(mp.clone()),
     );
 
-    let run_results = roms
-        .into_par_iter()
-        .progress_with(pb)
-        .map(|rom| {
-            let rom_name = rom
-                .path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .ok_or(anyhow!("Unable to get filename"))
-                .unwrap()
-                .to_owned();
+    let worker_statuses: Vec<Arc<WorkerStatus>> =
+        (0..jobs).map(|_| Arc::new(WorkerStatus::new())).collect();
 
-            panic::set_hook(Box::new(|_| {}));
+    let shutdown = new_shutdown();
 
-            let result = panic::catch_unwind({
-                let rom_name = rom_name.clone();
-                let rom_path = rom.path.clone();
-                || {
-                    let mut builder = GameBoyBuilder::new();
-
-                    if let Some(bios) = &bios {
-                        builder = builder.bios(bios.clone());
-                    }
-
-                    let mut gb = builder.rom(rom.bytes).build().unwrap();
-
-                    // Warm-up: run 40 emulated seconds (throttled if requested)
-                    run_emulated_ticks(&mut gb, partyboy_core::SPEED * 40, speed_factor, |_, _| {});
-
-                    let fourty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
-
-                    let mut pressed = false;
-                    // Main play period: 80 emulated seconds while mashing buttons (throttled)
-                    run_emulated_ticks(&mut gb, partyboy_core::SPEED * 80, speed_factor, |gb, tick| {
-                        if tick % (partyboy_core::SPEED / 2) == 0 {
-                            match pressed {
-                                true => {
-                                    gb.key_down(Keycode::A);
-                                    gb.key_up(Keycode::Start);
-                                }
-                                false => {
-                                    gb.key_up(Keycode::A);
-                                    gb.key_down(Keycode::Start);
-                                }
-                            }
-                            pressed = !pressed;
-                        }
-                    });
-
-                    let onetwenty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
-
-                    RunResult::Success {
-                        rom_name,
-                        fourty_seconds_frame_buffer,
-                        onetwenty_seconds_frame_buffer,
-                        rom_path,
-                    }
+    // A single UI driver thread polls worker statuses and updates bars, so workers
+    // never touch ProgressBar objects directly. Serializing draws here avoids races
+    // with mp.println from the writer/panic hook that would otherwise duplicate or
+    // freeze the bar block.
+    {
+        let statuses = worker_statuses.clone();
+        let bars = worker_bars.clone();
+        let shutdown = shutdown.clone();
+        thread::spawn(move || {
+            while current_shutdown(&shutdown) == ShutdownState::Running {
+                for (status, bar) in statuses.iter().zip(&bars) {
+                    let (rom, emul) = status.snapshot();
+                    bar.set_message(rom.unwrap_or_else(|| "idle".into()));
+                    bar.set_position(emul);
                 }
-            });
+                thread::sleep(Duration::from_millis(80));
+            }
+        });
+    }
 
-            match result {
-                Ok(run_result) => run_result,
-                Err(payload) => RunResult::Fail {
-                    rom_name,
-                    error: payload,
-                },
+    // Ctrl+C: first press = graceful drain, second = force exit.
+    {
+        let shutdown = shutdown.clone();
+        let count = Arc::new(AtomicU8::new(0));
+        ctrlc::set_handler(move || {
+            if count.fetch_add(1, Ordering::Relaxed) == 0 {
+                tracing::warn!("Ctrl+C received — finishing current ROMs then exiting (press again to force)");
+                request_shutdown(&shutdown, ShutdownState::Draining);
+            } else {
+                tracing::error!("Second Ctrl+C — forcing exit");
+                request_shutdown(&shutdown, ShutdownState::ForceKill);
+                process::exit(1);
             }
         })
-        .collect::<Vec<RunResult>>();
-
-    if !args.output.exists() {
-        fs::create_dir(&args.output)?;
+        .expect("Error setting Ctrl+C handler");
     }
 
-    println!();
-    println!();
+    let mut handles = Vec::with_capacity(jobs);
+    for status in &worker_statuses {
+        let status = status.clone();
+        let work_rx = work_rx.clone();
+        let result_tx = result_tx.clone();
+        let bios = bios.clone();
+        let speed = args.speed_factor;
+        let shutdown = shutdown.clone();
+        let global_bar = global_bar.clone();
 
-    let mut html = Vec::new();
-
-    for result in run_results {
-        match result {
-            RunResult::Success {
-                rom_name,
-                fourty_seconds_frame_buffer,
-                onetwenty_seconds_frame_buffer,
-                mut rom_path,
-            } => {
-                let fourty = into_img(fourty_seconds_frame_buffer);
-                let onetwenty = into_img(onetwenty_seconds_frame_buffer);
-
-                rom_path.set_extension("");
-                let name = rom_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .ok_or(anyhow!("Unable to get filename"))?;
-
-                fourty.save(args.output.join(format!("{name}_40.png")))?;
-                onetwenty.save(args.output.join(format!("{name}_120.png")))?;
-
-                let html_fragment = format!(
-                    r#"
-                    <div class="runner-result runner-success">
-                        <div>{rom_name}</div>
-                        <img src="{name}_40.png">
-                        <img src="{name}_120.png">
-                    </div>
-                "#
-                );
-
-                html.push(html_fragment);
-            }
-            RunResult::Fail { rom_name, error } => {
-                let msg = panic_message::panic_message(&error);
-
-                let html_fragment = format!(
-                    r#"
-                    <div class="runner-result runner-fail">
-                        <div>{rom_name}</div>
-                        <div>{msg}</div>
-                    </div>
-                "#
-                );
-
-                html.push(html_fragment);
-
-                eprintln!("A run failed:");
-                eprintln!("Rom: {rom_name}");
-                eprintln!("Error: {msg}");
-                eprintln!();
-            }
-        }
+        handles.push(thread::spawn(move || {
+            // Top-level safety net: run_one_rom catches its own panics and converts
+            // them to RunResult::Fail, so this only fires for the truly unexpected.
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                while current_shutdown(&shutdown) == ShutdownState::Running {
+                    let Ok(rom) = work_rx.recv() else { break };
+                    status.set_rom(Some(rom_display_name(&rom.path)));
+                    let res = run_one_rom(rom, bios.as_deref(), speed, Some(&status));
+                    let _ = result_tx.send(res);
+                    status.set_rom(None);
+                    global_bar.inc(1);
+                }
+            }));
+        }));
     }
 
-    let html = ["
-        <!DOCTYPE html>
-        <html>
-        <head>
-        <title>Page Title</title>
-        </head>
-        <body>
-    "
-    .to_owned()]
-    .into_iter()
-    .chain(html)
-    .chain(iter::once("</body></html>".to_owned()))
-    .collect::<String>();
+    for h in handles {
+        let _ = h.join();
+    }
 
-    fs::write(args.output.join("report.html"), html)
-        .map_err(|_| anyhow!("Unable to write html report file"))?;
+    request_shutdown(&shutdown, ShutdownState::Draining);
+    drop(result_tx);
+    let _ = writer_handle.join();
 
+    global_bar.finish_with_message("Done");
+    for b in &worker_bars {
+        b.finish_with_message("idle");
+    }
+
+    tracing::info!("Mass runner finished.");
     Ok(())
 }

--- a/partyboy-mass-runner/src/main.rs
+++ b/partyboy-mass-runner/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use image::{ImageBuffer, RgbImage};
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
-use partyboy_core::{builder::GameBoyBuilder, input::Keycode, ppu::rgb::Rgb};
+use partyboy_core::{builder::GameBoyBuilder, input::Keycode, ppu::rgb::Rgb, GameBoy};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[derive(Debug, Parser)]
@@ -22,6 +22,11 @@ struct Args {
 
     #[arg(short, long)]
     bios: Option<PathBuf>,
+
+    /// Target emulation speed as a multiplier of real time (e.g. 3.0 = 3x real-time).
+    /// Values <= 0 mean unlimited / original max-speed behavior.
+    #[arg(long, default_value_t = 3.0)]
+    speed_factor: f64,
 }
 
 #[allow(unused)]
@@ -68,6 +73,44 @@ fn into_img(fb: Vec<Rgb>) -> RgbImage {
     img
 }
 
+/// Run exactly `ticks` calls to `gb.tick()`, invoking `on_tick(gb, i)` after each tick.
+/// When `speed_factor > 0` the loop dynamically sleeps (using real wall time)
+/// so that the *average* emulation rate does not exceed `speed_factor` × real time.
+/// A factor <= 0 means "run as fast as possible" (original unlimited behavior).
+fn run_emulated_ticks<F>(gb: &mut GameBoy, ticks: u64, speed_factor: f64, mut on_tick: F)
+where
+    F: FnMut(&mut GameBoy, u64),
+{
+    if speed_factor <= 0.0 {
+        for i in 0..ticks {
+            let _ = gb.tick();
+            on_tick(gb, i);
+        }
+        return;
+    }
+
+    let start = std::time::Instant::now();
+    // Check once per emulated second — very low overhead and yields nice long sleeps
+    // that the OS scheduler can actually deschedule the thread for.
+    let check_every = partyboy_core::SPEED;
+
+    for i in 0..ticks {
+        let _ = gb.tick();
+        on_tick(gb, i);
+
+        if i % check_every == 0 {
+            let emulated_seconds = i as f64 / partyboy_core::SPEED as f64;
+            let desired_real_seconds = emulated_seconds / speed_factor;
+            let real_seconds = start.elapsed().as_secs_f64();
+            if real_seconds < desired_real_seconds {
+                std::thread::sleep(std::time::Duration::from_secs_f64(
+                    desired_real_seconds - real_seconds,
+                ));
+            }
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -84,6 +127,8 @@ fn main() -> Result<()> {
     } else {
         None
     };
+
+    let speed_factor = args.speed_factor;
 
     let roms = get_all_roms(&args.roms_dir)?;
 
@@ -123,16 +168,15 @@ fn main() -> Result<()> {
                     }
 
                     let mut gb = builder.rom(rom.bytes).build().unwrap();
-                    for _ in 0..(partyboy_core::SPEED * 40) {
-                        let _ = gb.tick();
-                    }
+
+                    // Warm-up: run 40 emulated seconds (throttled if requested)
+                    run_emulated_ticks(&mut gb, partyboy_core::SPEED * 40, speed_factor, |_, _| {});
 
                     let fourty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
 
                     let mut pressed = false;
-                    for tick in 0..(partyboy_core::SPEED * 80) {
-                        let _ = gb.tick();
-
+                    // Main play period: 80 emulated seconds while mashing buttons (throttled)
+                    run_emulated_ticks(&mut gb, partyboy_core::SPEED * 80, speed_factor, |gb, tick| {
                         if tick % (partyboy_core::SPEED / 2) == 0 {
                             match pressed {
                                 true => {
@@ -146,7 +190,7 @@ fn main() -> Result<()> {
                             }
                             pressed = !pressed;
                         }
-                    }
+                    });
 
                     let onetwenty_seconds_frame_buffer = gb.get_frame_buffer().to_vec();
 

--- a/partyboy-mass-runner/src/rom.rs
+++ b/partyboy-mass-runner/src/rom.rs
@@ -1,0 +1,44 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+pub struct Rom {
+    pub bytes: Vec<u8>,
+    pub path: PathBuf,
+}
+
+pub fn rom_display_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn get_all_roms(path: &Path) -> Result<Vec<Rom>> {
+    fs::read_dir(path)?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if entry.file_type().ok()?.is_dir() {
+                return None;
+            }
+            Some(entry.path())
+        })
+        .map(|path| Ok(Rom { bytes: fs::read(&path)?, path }))
+        .collect()
+}
+
+/// Skip ROMs already processed by a previous run: those with both success screenshots
+/// (`{stem}_40.png` + `{stem}_120.png`) or a recorded failure marker (`{stem}.failed`).
+pub fn filter_completed_for_resume(mut roms: Vec<Rom>, output_dir: &Path) -> Vec<Rom> {
+    roms.retain(|rom| {
+        let Some(stem) = rom.path.file_stem().and_then(|s| s.to_str()) else {
+            return true;
+        };
+        let p40 = output_dir.join(format!("{stem}_40.png"));
+        let p120 = output_dir.join(format!("{stem}_120.png"));
+        let failed = output_dir.join(format!("{stem}.failed"));
+        !((p40.exists() && p120.exists()) || failed.exists())
+    });
+    roms
+}

--- a/partyboy-mass-runner/src/types.rs
+++ b/partyboy-mass-runner/src/types.rs
@@ -1,0 +1,74 @@
+use std::any::Any;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use partyboy_core::ppu::rgb::Rgb;
+
+#[derive(Debug)]
+pub enum RunResult {
+    Success {
+        fourty_seconds_frame_buffer: Vec<Rgb>,
+        onetwenty_seconds_frame_buffer: Vec<Rgb>,
+        rom_path: PathBuf,
+    },
+    Fail {
+        rom_name: String,
+        error: Box<dyn Any + Send>,
+    },
+}
+
+/// Live status of one worker thread, polled by the UI driver to keep the per-worker bars
+/// in sync without letting workers touch ProgressBar objects directly.
+pub struct WorkerStatus {
+    rom_name: Mutex<Option<String>>,
+    emulated_seconds: AtomicU64,
+}
+
+impl WorkerStatus {
+    pub fn new() -> Self {
+        Self {
+            rom_name: Mutex::new(None),
+            emulated_seconds: AtomicU64::new(0),
+        }
+    }
+
+    pub fn set_rom(&self, name: Option<String>) {
+        *self.rom_name.lock().unwrap() = name;
+        self.emulated_seconds.store(0, Ordering::Relaxed);
+    }
+
+    pub fn update_emulated(&self, seconds: u64) {
+        self.emulated_seconds.store(seconds, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> (Option<String>, u64) {
+        let name = self.rom_name.lock().unwrap().clone();
+        (name, self.emulated_seconds.load(Ordering::Relaxed))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownState {
+    Running,
+    Draining,
+    ForceKill,
+}
+
+pub type Shutdown = Arc<AtomicU8>;
+
+pub fn new_shutdown() -> Shutdown {
+    Arc::new(AtomicU8::new(ShutdownState::Running as u8))
+}
+
+pub fn request_shutdown(shutdown: &Shutdown, state: ShutdownState) {
+    shutdown.store(state as u8, Ordering::SeqCst);
+}
+
+pub fn current_shutdown(shutdown: &Shutdown) -> ShutdownState {
+    match shutdown.load(Ordering::SeqCst) {
+        0 => ShutdownState::Running,
+        1 => ShutdownState::Draining,
+        _ => ShutdownState::ForceKill,
+    }
+}

--- a/partyboy-mass-runner/src/writer.rs
+++ b/partyboy-mass-runner/src/writer.rs
@@ -1,0 +1,202 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use anyhow::Result;
+use crossbeam::channel::Receiver;
+use indicatif::MultiProgress;
+
+use crate::emulator::into_img;
+use crate::types::RunResult;
+
+const ROM_EXTS: &[&str] = &[".gbc", ".gb", ".sgb"];
+
+/// Strip a trailing ROM extension (`.gbc`, `.gb`, `.sgb`) so display names, dedup keys,
+/// and marker filenames stay consistent regardless of where the input came from.
+fn clean_stem(name: &str) -> &str {
+    ROM_EXTS
+        .iter()
+        .fold(name, |acc, ext| acc.trim_end_matches(ext))
+}
+
+/// Background thread that saves screenshots, writes `.failed` markers, and rewrites the
+/// HTML report after each result. On startup it reconstructs state from disk so
+/// `--resume` produces a complete report even when no new ROMs need processing.
+pub fn spawn_writer_thread(
+    rx: Receiver<RunResult>,
+    output_dir: PathBuf,
+    completed: Arc<AtomicUsize>,
+    mp: Option<MultiProgress>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let log = |msg: String| match &mp {
+            Some(m) => {
+                let _ = m.println(msg);
+            }
+            None => tracing::info!("{}", msg),
+        };
+
+        let (mut successes, mut failures) = bootstrap_from_disk(&output_dir);
+        if !successes.is_empty() || !failures.is_empty() {
+            match write_html_report(&output_dir, &successes, &failures) {
+                Ok(()) => log(format!(
+                    "Regenerated report from disk: {} successes, {} failures",
+                    successes.len(),
+                    failures.len()
+                )),
+                Err(e) => log(format!("warning: failed to write initial report: {e}")),
+            }
+            completed.fetch_add(successes.len() + failures.len(), Ordering::Relaxed);
+        }
+
+        for result in rx {
+            match result {
+                RunResult::Success {
+                    fourty_seconds_frame_buffer,
+                    onetwenty_seconds_frame_buffer,
+                    mut rom_path,
+                } => {
+                    rom_path.set_extension("");
+                    let stem = rom_path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+
+                    let _ = into_img(fourty_seconds_frame_buffer)
+                        .save(output_dir.join(format!("{stem}_40.png")));
+                    let _ = into_img(onetwenty_seconds_frame_buffer)
+                        .save(output_dir.join(format!("{stem}_120.png")));
+
+                    if !successes.contains(&stem) {
+                        successes.push(stem);
+                    }
+                }
+                RunResult::Fail { rom_name, error } => {
+                    let msg = panic_message::panic_message(&error).to_string();
+                    log(format!("ERROR: ROM {rom_name} failed: {msg}"));
+
+                    let stem = clean_stem(&rom_name).to_string();
+                    let _ = fs::write(output_dir.join(format!("{stem}.failed")), &msg);
+                    if !failures.iter().any(|(name, _)| name == &stem) {
+                        failures.push((stem, msg));
+                    }
+                }
+            }
+
+            completed.fetch_add(1, Ordering::Relaxed);
+            if let Err(e) = write_html_report(&output_dir, &successes, &failures) {
+                log(format!("Failed to write report: {e}"));
+            }
+        }
+
+        if let Err(e) = write_html_report(&output_dir, &successes, &failures) {
+            log(format!("Final report write failed: {e}"));
+        }
+    })
+}
+
+/// Reconstruct `(successes, failures)` from `.failed` markers and matched `_40.png`/
+/// `_120.png` pairs in `output_dir`. Returns empty vecs if the dir doesn't exist.
+fn bootstrap_from_disk(output_dir: &Path) -> (Vec<String>, Vec<(String, String)>) {
+    let mut successes: Vec<String> = Vec::new();
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    let Ok(entries) = fs::read_dir(output_dir) else {
+        return (successes, failures);
+    };
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if name.ends_with(".failed") {
+            let stem = clean_stem(name.trim_end_matches(".failed")).to_string();
+            if let Ok(msg) = fs::read_to_string(&path) {
+                if !failures.iter().any(|(n, _)| n == &stem) {
+                    failures.push((stem, msg));
+                }
+            }
+        } else if let Some(stem) = name.strip_suffix("_40.png") {
+            if output_dir.join(format!("{stem}_120.png")).exists()
+                && !successes.iter().any(|n| n == stem)
+            {
+                successes.push(stem.to_string());
+            }
+        }
+    }
+
+    (successes, failures)
+}
+
+fn write_html_report(output_dir: &Path, successes: &[String], failures: &[(String, String)]) -> Result<()> {
+    let mut html = String::from(HTML_HEAD);
+
+    for stem in successes {
+        html.push_str(&format!(
+            r#"<div class="card"><div class="name">{stem}</div><img src="{stem}_40.png"><img src="{stem}_120.png"></div>"#
+        ));
+    }
+
+    html.push_str(HTML_MIDDLE);
+
+    for (name, msg) in failures {
+        html.push_str(&format!(r#"<div class="fail"><b>{name}</b><br>{msg}</div>"#));
+    }
+
+    html.push_str(HTML_FOOT);
+
+    let html = html
+        .replace("##success_count##", &successes.len().to_string())
+        .replace("##fail_count##", &failures.len().to_string());
+
+    fs::write(output_dir.join("report.html"), html)?;
+    Ok(())
+}
+
+const HTML_HEAD: &str = r##"<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Mass Runner Report</title>
+<style>
+:root { --bg:#0d0d0d; --card:#1a1a1a; --accent:#00aaff; }
+body { font-family: system-ui, sans-serif; background:var(--bg); color:#ddd; padding: 20px; }
+h1 { color: var(--accent); }
+.tabs { display:flex; gap: 10px; margin-bottom: 20px; }
+.tab-button { padding: 8px 16px; background:#222; border: none; color:#ddd; cursor:pointer; border-radius:4px; }
+.tab-button.active { background: var(--accent); color:black; }
+.tab-content { display:none; }
+.tab-content.active { display:block; }
+.grid { display: flex; flex-wrap: wrap; gap: 12px; }
+.card { background: var(--card); padding: 8px; border-radius: 6px; width: 200px; box-shadow: 0 2px 4px rgba(0,0,0,0.4); }
+.card .name { font-size: 0.85em; margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+img { width: 100%; image-rendering: pixelated; background:#000; }
+.fail-list .fail { background:#2a1212; padding:10px; margin-bottom:8px; border-radius:4px; font-family: monospace; font-size:0.9em; white-space: pre-wrap; }
+</style></head><body>
+<h1>Mass Runner Report</h1>
+<div class="tabs">
+  <button class="tab-button active" onclick="showTab('success')">Successes (##success_count##)</button>
+  <button class="tab-button" onclick="showTab('failures')">Failures (##fail_count##)</button>
+</div>
+
+<div id="success" class="tab-content active">
+  <div class="grid">
+"##;
+
+const HTML_MIDDLE: &str = r#"</div></div>
+<div id="failures" class="tab-content">
+  <div class="fail-list">
+"#;
+
+const HTML_FOOT: &str = r#"</div></div>
+<script>
+function showTab(tab) {
+  document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('.tab-button').forEach(el => el.classList.remove('active'));
+  document.getElementById(tab).classList.add('active');
+  event.target.classList.add('active');
+}
+</script>
+</body></html>"#;


### PR DESCRIPTION
Adds `partyboy-mass-runner`: a CLI that batch-runs every ROM in a directory through
  partyboy-core to catch emulator regressions across a large corpus. Each ROM gets a
  40s warm-up pass and an 80s pass with alternating Start/A inputs; screenshots from
  both phases are saved as PNGs and rolled up into an HTML report with success/failure
  tabs.

  - Configurable concurrency (`-j`), emulation speed multiplier (`--speed-factor`),
    optional BIOS, and `--resume` to skip ROMs that already have screenshots or a
    recorded failure marker.
  - Live TUI via `indicatif`: one global progress bar plus a per-worker bar showing
    the current ROM and emulated seconds. A single UI driver thread owns all draws so
    worker threads only touch a cheap `WorkerStatus` atomic snapshot.
  - Crashes in `partyboy-core` (unhandled MBC mappers, unwrap() in CPU/bus paths) are
    caught per-ROM via `catch_unwind`, recorded as `.failed` markers, and surfaced in
    the report. The default panic hook is rerouted through `MultiProgress::println`
    so panic output no longer interleaves with the bar redraws.
  - Graceful Ctrl+C: first press drains in-flight ROMs, second press force-exits.
  - New `release-unwind` cargo profile (`panic = "unwind"`) so the crash-catching path
    actually works in optimized builds — the default `release` still uses `panic = "abort"`.